### PR TITLE
Fix for #18 - add Required Stop to LSB header

### DIFF
--- a/debian/updateInit.sh
+++ b/debian/updateInit.sh
@@ -8,6 +8,7 @@ perl -i -ne 'if (m@^#!/bin/bash@) {
 ### BEGIN INIT INFO
 # Provides:       nv_peer_mem
 # Required-Start: openibd
+# Required-Stop:
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
 # Description:    Activates/Deactivates nv_peer_mem to \


### PR DESCRIPTION
This is a pretty simple change, and eliminates a lot of scary looking insserv  error messages when running systemd.