### PR TITLE
Check for nvidia_p2p* symbols instead of __crc_nvidia_p2p* symbols.

### DIFF
--- a/create_nv.symvers.sh
+++ b/create_nv.symvers.sh
@@ -36,7 +36,7 @@ do
 	if [ ! -e "$nvidia_mod" ]; then
 		continue
 	fi
-	if ! (nm -o $nvidia_mod | grep -q "__crc_nvidia_p2p_"); then
+	if ! (nm -o $nvidia_mod | grep -q " nvidia_p2p_"); then
 		continue
 	fi
 


### PR DESCRIPTION
I believe the __crc* will be present only if CONFIG_MODVERSIONS was enabled, which doesn't seem to be a mandatory requirement.