### PR TITLE
Revert "debian: Add dependency on cuda"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Description: nvidia peer memory kernel module.
 Package: nvidia-peer-memory-dkms
 Section: kernel
 Architecture: all
-Depends: dkms, make, mlnx-ofed-kernel-dkms | mlnx-ofed-kernel-modules, cuda, ${misc:Depends}
+Depends: dkms, make, mlnx-ofed-kernel-dkms | mlnx-ofed-kernel-modules, ${misc:Depends}
 Recommends: linux-headers-arm64 | linux-headers-powerpc | linux-headers-ppc64 | linux-headers-ppc64le | linux-headers-amd64 | linux-headers-generic | linux-headers
 Description: DKMS support for nvidia-peer-memory kernel modules
  This package provides integration with the DKMS infrastructure for automatically building out of tree kernel modules.

--- a/dkms.conf
+++ b/dkms.conf
@@ -10,7 +10,7 @@ kernel_source_dir=${kernel_source_dir:-/lib/modules/$kernelver/build}
 BUILT_MODULE_NAME[0]="nv_peer_mem"
 BUILT_MODULE_LOCATION[0]="./"
 DEST_MODULE_LOCATION[0]="/kernel/../updates/"
-BUILD_DEPENDS[0]="mlnx-ofed-kernel cuda"
+BUILD_DEPENDS[0]="mlnx-ofed-kernel"
 MAKE="make all KVER=$kernelver KDIR=$kernel_source_dir"
 
 # Cleanup command-line


### PR DESCRIPTION
This reverts commit 2e28f47364d3850e4c59f3f1001f61d2b2d9f79a.

The Nvidia DGX-1 series installs nvidia-peer-memory, but does not have cuda installed.

Signed-off-by: Alaa Hleihel <alaa@mellanox.com>