### PR TITLE
build_module.sh: Reorder parameters of tar

### DIFF
--- a/build_module.sh
+++ b/build_module.sh
@@ -28,7 +28,7 @@ fi
 
 ex cp -r . $tmpdir/nvidia_peer_memory-$VERSION
 pushd $tmpdir > /dev/null
-ex tar czf nvidia_peer_memory-$VERSION.tar.gz nvidia_peer_memory-$VERSION --exclude=.* --exclude=build_release.sh
+ex tar czf nvidia_peer_memory-$VERSION.tar.gz  --exclude='.*' --exclude=build_release.sh nvidia_peer_memory-$VERSION
 popd > /dev/null
 
 if [ -f /etc/debian_version ]; then
@@ -36,7 +36,7 @@ if [ -f /etc/debian_version ]; then
     echo "Building debian tarball for nvidia-peer-memory..."
     ex mv $tmpdir/nvidia_peer_memory-$VERSION $tmpdir/nvidia-peer-memory-$VERSION
     pushd $tmpdir > /dev/null
-    ex tar czf nvidia-peer-memory_$VERSION.orig.tar.gz nvidia-peer-memory-$VERSION --exclude=.* --exclude=build_release.sh
+    ex tar czf nvidia-peer-memory_$VERSION.orig.tar.gz --exclude='.*' --exclude=build_release.sh nvidia-peer-memory-$VERSION
     ex mv nvidia-peer-memory_$VERSION.orig.tar.gz /tmp
     popd > /dev/null
 


### PR DESCRIPTION
On Ubuntu 19.10 tar gives the following error:

tar: The following options were used after any non-optional arguments in
archive create or update mode.  These options are positional and affect
only arguments that follow them.  Please, rearrange them properly.
tar: --exclude .* has no effect
tar: --exclude build_release.sh has no effect
tar: Exiting with failure status due to previous errors

Signed-off-by: Tzafrir Cohen <mellanox@cohens.org.il>