### PR TITLE
debian: use native source format

### DIFF
--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
This git repo is self contained so it is reasonalbe native format,
so command "dpkg-source --build ." will works