### PR TITLE
Dkms directory

### DIFF
--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -5,4 +5,4 @@
 files
 nvidia-peer-memory-dkms/
 nvidia-peer-memory/
-
+tmp

--- a/debian/nvidia-peer-memory-dkms.install
+++ b/debian/nvidia-peer-memory-dkms.install
@@ -1,0 +1,1 @@
+usr/src/nv_peer_mem-*/*

--- a/debian/nvidia-peer-memory.install
+++ b/debian/nvidia-peer-memory.install
@@ -1,0 +1,3 @@
+etc/infiniband/nv_peer_mem.conf
+etc/init.d/nv_peer_mem
+etc/init/nv_peer_mem.conf

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,7 @@
 
 pname:=nvidia-peer-memory
 pdkms:=$(pname)-dkms
+dkms_pkg:=nv_peer_mem-$(pversion)
 pversion := $(shell dpkg-parsechangelog | sed -n 's/^Version: *\([^-]\+\)-.\+/\1/p')
 
 %:
@@ -20,12 +21,12 @@ override_dh_auto_test:
 
 override_dh_auto_install:
 	# For dkms
-	dh_installdirs -p$(pdkms)  usr/src/$(pname)-$(pversion)
-	cp -a Makefile             debian/$(pdkms)/usr/src/$(pname)-$(pversion)
-	cp -a compat_nv-p2p.h             debian/$(pdkms)/usr/src/$(pname)-$(pversion)
-	cp -a nv_peer_mem.c        debian/$(pdkms)/usr/src/$(pname)-$(pversion)
-	cp -a create_nv.symvers.sh           debian/$(pdkms)/usr/src/$(pname)-$(pversion)
-	cp -a dkms.conf            debian/$(pdkms)/usr/src/$(pname)-$(pversion)
+	dh_installdirs -p$(pdkms)  usr/src/$(dkms_pkg)
+	cp -a Makefile             debian/$(pdkms)/usr/src/$(dkms_pkg)
+	cp -a compat_nv-p2p.h             debian/$(pdkms)/usr/src/$(dkms_pkg)
+	cp -a nv_peer_mem.c        debian/$(pdkms)/usr/src/$(dkms_pkg)
+	cp -a create_nv.symvers.sh           debian/$(pdkms)/usr/src/$(dkms_pkg)
+	cp -a dkms.conf            debian/$(pdkms)/usr/src/$(dkms_pkg)
 
 	# utils
 	dh_installdirs -p$(pname)  /etc/infiniband/

--- a/debian/rules
+++ b/debian/rules
@@ -20,22 +20,7 @@ override_dh_auto_build:
 override_dh_auto_test:
 
 override_dh_auto_install:
-	# For dkms
-	dh_installdirs -p$(pdkms)  usr/src/$(dkms_pkg)
-	cp -a Makefile             debian/$(pdkms)/usr/src/$(dkms_pkg)
-	cp -a compat_nv-p2p.h             debian/$(pdkms)/usr/src/$(dkms_pkg)
-	cp -a nv_peer_mem.c        debian/$(pdkms)/usr/src/$(dkms_pkg)
-	cp -a create_nv.symvers.sh           debian/$(pdkms)/usr/src/$(dkms_pkg)
-	cp -a dkms.conf            debian/$(pdkms)/usr/src/$(dkms_pkg)
-
-	# utils
-	dh_installdirs -p$(pname)  /etc/infiniband/
-	install -m 0644 nv_peer_mem.conf            debian/$(pname)/etc/infiniband/nv_peer_mem.conf
-	dh_installdirs -p$(pname)  /etc/init.d/
-	install -m 0755 nv_peer_mem                 debian/$(pname)/etc/init.d/nv_peer_mem
-	# add info needed to load the module on boot
-	$(CURDIR)/debian/updateInit.sh debian/$(pname)/etc/init.d/nv_peer_mem
-	dh_installdirs -p$(pname)  /etc/init/
-	install -m 0755 nv_peer_mem.upstart         debian/$(pname)/etc/init/nv_peer_mem.conf
+	make DESTDIR=$(CURDIR)/debian/tmp install-dkms install-utils
+	$(CURDIR)/debian/updateInit.sh debian/tmp/etc/init.d/nv_peer_mem
 
 override_dh_installinit:


### PR DESCRIPTION
First commit fixes an issue in which dkms sources were installed to the wrong directory and an install of the dkms package thus failed because /usr/src/nv_peer_mem-1.1 only included dkms.conf .

Second commit moves file copying from debian/rules into the Makefile. The target install-utils could eventually be used by the spec as well.