### PR TITLE
add support for new style peer memory client registration, fix a race

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Installation
 
 Pre-requisites:
 1) NVIDIA compatible driver is installed and up.
-2) MLNX_OFED 2.1 is installed and up.
+2) MLNX_OFED 5.1 or newer is installed and up.
+
+Please note that to build correctly, a MLNX_OFED carrying the Peer-direct fix for the bug "Peer-direct patch may cause deadlock due to lock inversion" (tracked by the Internal Ref. #2696789) is required, for example MLNX_OFED 5.3-1.0.0.1.43.
 
 For the required NVIDIA driver and other relevant details in that area
 please check with NVIDIA support.

--- a/README.md
+++ b/README.md
@@ -33,30 +33,31 @@ please check with NVIDIA support.
 To build source packages (src.rpm for RPM based OS and tarball for DEB based OS), use the build_module.sh script.
 
 
-Example:
+For example, to build on RPM based OS:
 
     $ ./build_module.sh
-
     Building source rpm for nvidia_peer_memory...
-    Building debian tarball for nvidia-peer-memory...
-
-    Built: /tmp/nvidia_peer_memory-1.1-0.src.rpm
-    Built: /tmp/nvidia-peer-memory_1.0.orig.tar.gz
-
-To install on RPM based OS:
-
-    # rpmbuild --rebuild /tmp/nvidia_peer_memory-1.1-0.src.rpm
+    
+    Built: /tmp/nvidia_peer_memory-1.2-0.src.rpm
+    
+    To install run on RPM based OS:
+    # rpmbuild --rebuild /tmp/nvidia_peer_memory-1.2-0.src.rpm
     # rpm -ivh <path to generated binary rpm file>
 
-To install on DEB based OS:
+To build on DEB based OS:
 
+    Building debian tarball for nvidia-peer-memory...
+    
+    Built: /tmp/nvidia-peer-memory_1.2.orig.tar.gz
+
+    To install on DEB based OS:
     # cd /tmp
-    # tar xzf /tmp/nvidia-peer-memory_1.0.orig.tar.gz
-    # cd nvidia-peer-memory-1.0
+    # tar xzf /tmp/nvidia-peer-memory_1.2.orig.tar.gz
+    # cd nvidia-peer-memory-1.2
     # dpkg-buildpackage -us -uc
-    # dpkg -i <path to generated deb files>
+    # dpkg -i <path to generated deb files>            
 
-To install run (excluding ubuntu):
+To install run (excluding Ubuntu):
 
     rpmbuild --rebuild <path to srpm>.
     rpm -ivh <path to generated binary rpm file.> [On SLES add --nodeps].
@@ -66,8 +67,8 @@ To install on Ubuntu run:
     dpkg-buildpackage -us -uc
     dpkg -i <path to generated deb files.>
 
-    (e.g. dpkg -i nvidia-peer-memory_1.1-0_all.deb
-          dpkg -i nvidia-peer-memory-dkms_1.1-0_all.deb)
+    (e.g. dpkg -i nvidia-peer-memory_1.2-0_all.deb
+          dpkg -i nvidia-peer-memory-dkms_1.2-0_all.deb)
 
 After successful installation:
 1)	nv_peer_mem.ko is installed

--- a/create_nv.symvers.sh
+++ b/create_nv.symvers.sh
@@ -74,7 +74,7 @@ nvidia_mod=
 crc_found=0
 crc_mod_str="__crc_nvidia_p2p_"
 modules_pat="$crc_mod_str|T nvidia_p2p_"
-for mod in nvidia $(ls /lib/modules/$KVER/updates/dkms/nvidia*.ko* 2>/dev/null)
+for mod in nvidia $(find /lib/modules/$KVER -name "nvidia*.ko*" 2>/dev/null)
 do
 	nvidia_mod=$(/sbin/modinfo -F filename -k "$KVER" $mod 2>/dev/null)
 	if [ ! -e "$nvidia_mod" ]; then

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nvidia-peer-memory (1.2-0) unstable; urgency=low
+
+  *  nv_peer_mem.c: avoid deadlocks by registering as new style client
+
+ -- Feras Daoud <ferasda@nvidia.com>  Mon, 27 Jul 2020 16:01:20 +0200
+
 nvidia-peer-memory (1.1-0) unstable; urgency=low
 
   *  Makefile: Support compiling without MLNX_OFED

--- a/debian/patches/dkms_name.patch
+++ b/debian/patches/dkms_name.patch
@@ -10,6 +10,6 @@ index 7315b92..0b966e1 100644
  # DKMS module name and version
 -PACKAGE_NAME="nv_peer_mem"
 +PACKAGE_NAME="nvidia-peer-memory"
- PACKAGE_VERSION="1.1"
+ PACKAGE_VERSION="1.2"
  
  kernelver=${kernelver:-$(uname -r)}

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,7 @@
 
 # DKMS module name and version
 PACKAGE_NAME="nv_peer_mem"
-PACKAGE_VERSION="1.1"
+PACKAGE_VERSION="1.2"
 
 kernelver=${kernelver:-$(uname -r)}
 kernel_source_dir=${kernel_source_dir:-/lib/modules/$kernelver/build}

--- a/nv_peer_mem.c
+++ b/nv_peer_mem.c
@@ -46,7 +46,7 @@
 #include <rdma/peer_mem.h>
 
 #define DRV_NAME	"nv_mem"
-#define DRV_VERSION	"1.1-0"
+#define DRV_VERSION	"1.2-0"
 #define DRV_RELDATE	__DATE__
 
 

--- a/nv_peer_mem.c
+++ b/nv_peer_mem.c
@@ -364,10 +364,15 @@ static void nv_mem_put_pages(struct sg_table *sg_head, void *context)
 	struct nv_mem_context *nv_mem_context =
 		(struct nv_mem_context *) context;
 
-	if (nv_mem_context->callback_task == current)
+	if (!nv_mem_context) {
+		peer_err("nv_mem_put_pages -- invalid nv_mem_context\n");
 		return;
+	}
 
 	if (WARN_ON(0 != memcmp(sg_head, &nv_mem_context->sg_head, sizeof(*sg_head))))
+		return;
+
+	if (nv_mem_context->callback_task == current)
 		return;
 
 	ret = nvidia_p2p_put_pages(0, 0, nv_mem_context->page_virt_start,

--- a/nv_peer_mem.c
+++ b/nv_peer_mem.c
@@ -467,44 +467,44 @@ static unsigned long nv_mem_get_page_size(void *context)
 }
 
 static struct peer_memory_client_ex nv_mem_client_ex = { .client = {
-    .acquire        = nv_mem_acquire,
-    .get_pages  = nv_mem_get_pages,
-    .dma_map    = nv_dma_map,
-    .dma_unmap  = nv_dma_unmap,
-    .put_pages  = nv_mem_put_pages,
-    .get_page_size  = nv_mem_get_page_size,
-    .release        = nv_mem_release,
+	.acquire        = nv_mem_acquire,
+	.get_pages  = nv_mem_get_pages,
+	.dma_map    = nv_dma_map,
+	.dma_unmap  = nv_dma_unmap,
+	.put_pages  = nv_mem_put_pages,
+	.get_page_size  = nv_mem_get_page_size,
+	.release        = nv_mem_release,
 }};
 
 static int __init nv_mem_client_init(void)
 {
-    // off by one, to leave space for the trailing '1' which is flagging
-    // the new client type
-    BUG_ON(strlen(DRV_NAME) > IB_PEER_MEMORY_NAME_MAX-1);
-    strcpy(nv_mem_client_ex.client.name, DRV_NAME);
+	// off by one, to leave space for the trailing '1' which is flagging
+	// the new client type
+	BUG_ON(strlen(DRV_NAME) > IB_PEER_MEMORY_NAME_MAX-1);
+	strcpy(nv_mem_client_ex.client.name, DRV_NAME);
 
-    // [VER_MAX-1]=1 <-- last byte is used as flag
-    // [VER_MAX-2]=0 <-- version string terminator
-    BUG_ON(strlen(DRV_VERSION) > IB_PEER_MEMORY_VER_MAX-2);
-    strcpy(nv_mem_client_ex.client.version, DRV_VERSION);
+	// [VER_MAX-1]=1 <-- last byte is used as flag
+	// [VER_MAX-2]=0 <-- version string terminator
+	BUG_ON(strlen(DRV_VERSION) > IB_PEER_MEMORY_VER_MAX-2);
+	strcpy(nv_mem_client_ex.client.version, DRV_VERSION);
 
-    // Register as new-style client
-    // Needs updated peer_mem patch, but is harmless otherwise
-    nv_mem_client_ex.client.version[IB_PEER_MEMORY_VER_MAX-1] = 1;
-    nv_mem_client_ex.ex_size = sizeof(struct peer_memory_client_ex);
+	// Register as new-style client
+	// Needs updated peer_mem patch, but is harmless otherwise
+	nv_mem_client_ex.client.version[IB_PEER_MEMORY_VER_MAX-1] = 1;
+	nv_mem_client_ex.ex_size = sizeof(struct peer_memory_client_ex);
 
-    // PEER_MEM_INVALIDATE_UNMAPS allow clients to opt out of
-    // unmap/put_pages during invalidation, i.e. the client tells the
-    // infiniband layer that it does not need to call
-    // unmap/put_pages in the invalidation callback
-    nv_mem_client_ex.flags = PEER_MEM_INVALIDATE_UNMAPS;
+	// PEER_MEM_INVALIDATE_UNMAPS allow clients to opt out of
+	// unmap/put_pages during invalidation, i.e. the client tells the
+	// infiniband layer that it does not need to call
+	// unmap/put_pages in the invalidation callback
+	nv_mem_client_ex.flags = PEER_MEM_INVALIDATE_UNMAPS;
 
-    reg_handle = ib_register_peer_memory_client(&nv_mem_client_ex.client,
-                         &mem_invalidate_callback);
-    if (!reg_handle)
-        return -EINVAL;
+	reg_handle = ib_register_peer_memory_client(&nv_mem_client_ex.client,
+						    &mem_invalidate_callback);
+	if (!reg_handle)
+		return -EINVAL;
 
-    return 0;
+	return 0;
 }
 
 static void __exit nv_mem_client_cleanup(void)

--- a/nv_peer_mem.c
+++ b/nv_peer_mem.c
@@ -351,10 +351,12 @@ static int nv_dma_unmap(struct sg_table *sg_head, void *context,
 	if (WARN_ON(0 != memcmp(sg_head, &nv_mem_context->sg_head, sizeof(*sg_head))))
 		return -EINVAL;
 
-        peer_dbg("nv_mem_context=%p\n", nv_mem_context);
-
-	if (nv_mem_context->callback_task == current)
+	if (nv_mem_context->callback_task == current) {
+		peer_dbg("no-op in callback context\n");
 		goto out;
+	}
+
+	peer_dbg("nv_mem_context=%p\n", nv_mem_context);
 
 #if NV_DMA_MAPPING
 	{
@@ -384,10 +386,12 @@ static void nv_mem_put_pages(struct sg_table *sg_head, void *context)
 	if (WARN_ON(0 != memcmp(sg_head, &nv_mem_context->sg_head, sizeof(*sg_head))))
 		return;
 
-	peer_dbg("nv_mem_context=%p\n", nv_mem_context);
-
-	if (nv_mem_context->callback_task == current)
+	if (nv_mem_context->callback_task == current) {
+            	peer_dbg("no-op in callback context\n");
 		return;
+        }
+
+        peer_dbg("nv_mem_context=%p\n", nv_mem_context);
 
 	ret = nvidia_p2p_put_pages(0, 0, nv_mem_context->page_virt_start,
 				   nv_mem_context->page_table);

--- a/nv_peer_mem.c
+++ b/nv_peer_mem.c
@@ -49,6 +49,10 @@
 #define DRV_VERSION	"1.2-0"
 #define DRV_RELDATE	__DATE__
 
+MODULE_AUTHOR("Yishai Hadas");
+MODULE_DESCRIPTION("NVIDIA GPU memory plug-in");
+MODULE_LICENSE("Dual BSD/GPL");
+MODULE_VERSION(DRV_VERSION);
 
 #define peer_err(FMT, ARGS...) printk(KERN_ERR   DRV_NAME " %s:%d " FMT, __FUNCTION__, __LINE__, ## ARGS)
 
@@ -100,11 +104,6 @@ MODULE_PARM_DESC(enable_dbg, "enable debug tracing");
 #ifndef WRITE_ONCE
 #define WRITE_ONCE(x, val) ({ ACCESS_ONCE(x) = (val); })
 #endif
-
-MODULE_AUTHOR("Yishai Hadas");
-MODULE_DESCRIPTION("NVIDIA GPU memory plug-in");
-MODULE_LICENSE("Dual BSD/GPL");
-MODULE_VERSION(DRV_VERSION);
 
 #define GPU_PAGE_SHIFT   16
 #define GPU_PAGE_SIZE    ((u64)1 << GPU_PAGE_SHIFT)

--- a/nvidia_peer_memory.spec
+++ b/nvidia_peer_memory.spec
@@ -6,7 +6,7 @@
 
 Summary: nvidia_peer_memory
 Name: nvidia_peer_memory
-Version: 1.1
+Version: 1.2
 Release: %{_release}
 License: GPL
 Group: System Environment/Libraries


### PR DESCRIPTION
With this change, this client registers itself as an extended client. This way it can opt into a new behavior, i.e. unmap during invalidation. 

The Infiniband peer_mem kernel infrastructure reacts by avoiding calls to dma_unmap and put_pages client callbacks in the invalidation path, therefore not taking the internal lock, i.e. umem_p->mapping_lock. That avoids a lock inversion bug between the umem_p->mapping_lock and an internal NVIDIA GPU kernel-mode driver lock, tracked as [2696789 ](https://docs.mellanox.com/display/MLNXOFEDv53100143/Bug+Fixes)"Peer-direct patch may cause deadlock due to lock inversion".

Note that the change is compatible with older versions of the peer_mem patch, in the sense that the client registers successfully in all cases, but the lock inversion problem persists.

Bonus: fix a race in nv_mem_put_pages which has been around basically forever.