### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,9 @@ Installation
 
 Pre-requisites:
 1) NVIDIA compatible driver is installed and up.
-2) MLNX_OFED 5.1 or newer is installed and up.
+2) MLNX_OFED 2.1 or newer is installed and up.
 
-Please note that to build correctly, a MLNX_OFED carrying the Peer-direct fix for the bug "Peer-direct patch may cause deadlock due to lock inversion" (tracked by the Internal Ref. #2696789) is required, for example MLNX_OFED 5.3-1.0.0.1.43.
-
-For the required NVIDIA driver and other relevant details in that area
-please check with NVIDIA support.
+For the required NVIDIA driver and other relevant details in that area please check with NVIDIA support.
 
 To build source packages (src.rpm for RPM based OS and tarball for DEB based OS), use the build_module.sh script.
 
@@ -77,3 +74,5 @@ Notes
 
 To achieve good performance both the NIC and the GPU must physically sit on same i/o root complex,
 use lspci -tv to make sure that this is the case.
+
+Version 1.2 or newer, together with a recent MLNX_OFED, for example MLNX_OFED 5.3-1.0.0.1.43, are required to avoid a lock-inversion deadlock (tracked by the Internal Ref. #2696789) which may arise in certain situations when using the Peer-direct technology.


### PR DESCRIPTION
MLNX_OFED 5.1 is not required to build v1.2:
- remove build requirement
- revert to MLNX_OFED 2.1
- add a note regarding v1.2 and recent MLNX_OFED being necessary to solve 2696789