### PR TITLE
Avoid getting version from spec when not DKMS build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ MODULE_DESTDIR := $(MODULES_DIR)/extra/
 DEPMOD := /sbin/depmod
 
 MOD_NAME := nv_peer_mem
-MOD_VERSION := $(shell awk '/^Version:/ {print $$2}' nvidia_peer_memory.spec)
-DKMS_SRC_DIR := /usr/src/$(MOD_NAME)-$(MOD_VERSION)
+MOD_VERSION = $(shell awk '/^Version:/ {print $$2}' nvidia_peer_memory.spec)
+DKMS_SRC_DIR = /usr/src/$(MOD_NAME)-$(MOD_VERSION)
 SOURCE_FILES := Makefile compat_nv-p2p.h nv_peer_mem.c \
   create_nv.symvers.sh dkms.conf
 


### PR DESCRIPTION
In the Makefile, MOD_VERSION is only used to set DKMS_SRC_DIR which is
only used in the DKMS build. In that case, the tarball includes the spec
file. However, the build script does not export the spec file in the
build tarball.

There is no need to get MOD_VERSION in any build except when calling
DKMS. Therefore no point in generating it on every run of make. ':='
is intended to optimize performence but here it causes useless
invocations.

Signed-off-by: Tzafrir Cohen <nvidia@cohens.org.il>