### PR TITLE
Makefile: FIXUP: remove debug target "first"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,6 @@ OFA_DIR ?= /usr/src/ofa_kernel
 OFA_CANDIDATES = $(OFA_DIR)/$(OFA_ARCH)/$(KVER) $(OFA_DIR)/$(KVER) $(OFA_DIR)/default /var/lib/dkms/mlnx-ofed-kernel
 OFA_KERNEL ?= $(shell for d in $(OFA_CANDIDATES); do if [ -d "$$d" ]; then echo "$$d"; exit 0; fi; done; echo $(OFA_DIR))
 
-first:
-	@echo OFA_DIR: $(OFA_DIR)
-	@echo OFA_KERNEL: $(OFA_KERNEL)
-
 ifneq ($(shell test -d $(OFA_KERNEL) && echo "true" || echo "" ),)
 $(info INFO: Building with MLNX_OFED from: $(OFA_KERNEL))
 ccflags-y += -I$(OFA_KERNEL)/include/ -I$(OFA_KERNEL)/include/rdma


### PR DESCRIPTION
Fixes commit 93e45c5849f04 ("Makefile: cleaner setting of OFA_KERNEL").

Signed-off-by: Tzafrir Cohen <nvidia@cohens.org.il>