### PR TITLE
1 1 0 release jetson

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,12 @@ endif
 # Get nv-p2p.h header file of the currently installed CUDA version.
 # Try to get it based on available nvidia module version (just in case there are sources for couple of versions)
 nv_version=$(shell /sbin/modinfo -F version -k $(KVER) nvidia 2>/dev/null)
-nv_sources=$(shell /bin/ls -d /usr/src/nvidia-$(nv_version)/ 2>/dev/null)
+#nv_sources=$(shell /bin/ls -d /usr/src/nvidia-$(nv_version)/ 2>/dev/null)
+nv_sources=$(shell /bin/ls -d /usr/src/linux-headers-4.9.201-tegra-ubuntu18.04_aarch64/nvgpu/ 2>/dev/null)
+
 ifneq ($(shell test -d "$(nv_sources)" && echo "true" || echo "" ),)
-NV_P2P_H=$(shell /bin/ls -1 $(nv_sources)/nvidia/nv-p2p.h 2>/dev/null | tail -1)
+#NV_P2P_H=$(shell /bin/ls -1 $(nv_sources)/nvidia/nv-p2p.h 2>/dev/null | tail -1)
+NV_P2P_H=$(shell /bin/ls -1 $(nv_sources)/include/linux/nv-p2p.h 2>/dev/null | tail -1)
 else
 NV_P2P_H=$(shell /bin/ls -1 /usr/src/nvidia-*/nvidia/nv-p2p.h 2>/dev/null | tail -1)
 endif

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ Example:
     Building source rpm for nvidia_peer_memory...
     Building debian tarball for nvidia-peer-memory...
 
-    Built: /tmp/nvidia_peer_memory-1.0-9.src.rpm
+    Built: /tmp/nvidia_peer_memory-1.1-0.src.rpm
     Built: /tmp/nvidia-peer-memory_1.0.orig.tar.gz
 
 To install on RPM based OS:
 
-    # rpmbuild --rebuild /tmp/nvidia_peer_memory-1.0-9.src.rpm
+    # rpmbuild --rebuild /tmp/nvidia_peer_memory-1.1-0.src.rpm
     # rpm -ivh <path to generated binary rpm file>
 
 To install on DEB based OS:
@@ -64,8 +64,8 @@ To install on Ubuntu run:
     dpkg-buildpackage -us -uc
     dpkg -i <path to generated deb files.>
 
-    (e.g. dpkg -i nvidia-peer-memory_1.0-9_all.deb
-          dpkg -i nvidia-peer-memory-dkms_1.0-9_all.deb)
+    (e.g. dpkg -i nvidia-peer-memory_1.1-0_all.deb
+          dpkg -i nvidia-peer-memory-dkms_1.1-0_all.deb)
 
 After successful installation:
 1)	nv_peer_mem.ko is installed

--- a/create_nv.symvers.sh
+++ b/create_nv.symvers.sh
@@ -74,14 +74,16 @@ nvidia_mod=
 crc_found=0
 crc_mod_str="__crc_nvidia_p2p_"
 modules_pat="$crc_mod_str|T nvidia_p2p_"
-for mod in nvidia $(ls /lib/modules/$KVER/updates/dkms/nvidia*.ko* 2>/dev/null)
+#for mod in nvidia $(ls /lib/modules/$KVER/updates/dkms/nvidia*.ko* 2>/dev/null)
+for mod in nvidia $(ls /lib/modules/4.9.201-tegra/kernel/drivers/gpu/nvgpu/nvgpu.ko 2>/dev/null)
 do
 	nvidia_mod=$(/sbin/modinfo -F filename -k "$KVER" $mod 2>/dev/null)
 	if [ ! -e "$nvidia_mod" ]; then
 		continue
 	fi
 
-	# WA for nm: nvidia.ko.xz: File format not recognized
+	# //WA for nm: nvidia.ko.xz: File format not recognized//
+	# WA for nm: nvgpu.ko.xz: File format not recognized
 	case "$nvidia_mod" in
 		*ko.xz)
 			/bin/cp -fv $nvidia_mod .

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+nvidia-peer-memory (1.1-0) unstable; urgency=low
+
+  *  Makefile: Support compiling without MLNX_OFED
+  *  Makefile: Imporve parsing /proc/version
+  *  Add EXPORT_SYMBOL to symver
+
+ -- Feras Daoud <ferasda@nvidia.com>  Mon, 27 Jul 2020 16:01:20 +0200
+
 nvidia-peer-memory (1.0-9) unstable; urgency=low
 
   *  create_nv.symvers.sh: avoid non-crc syms on old

--- a/debian/patches/dkms_name.patch
+++ b/debian/patches/dkms_name.patch
@@ -10,6 +10,6 @@ index 7315b92..0b966e1 100644
  # DKMS module name and version
 -PACKAGE_NAME="nv_peer_mem"
 +PACKAGE_NAME="nvidia-peer-memory"
- PACKAGE_VERSION="1.0"
+ PACKAGE_VERSION="1.1"
  
  kernelver=${kernelver:-$(uname -r)}

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,7 @@
 
 # DKMS module name and version
 PACKAGE_NAME="nv_peer_mem"
-PACKAGE_VERSION="1.0"
+PACKAGE_VERSION="1.1"
 
 kernelver=${kernelver:-$(uname -r)}
 kernel_source_dir=${kernel_source_dir:-/lib/modules/$kernelver/build}

--- a/nv-p2p.h.org
+++ b/nv-p2p.h.org
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __NVIDIA_P2P_H__
+#define __NVIDIA_P2P_H__
+
+#include <linux/dma-mapping.h>
+#include <linux/mmu_notifier.h>
+
+#define	NVIDIA_P2P_UNINITIALIZED 0x0
+#define	NVIDIA_P2P_PINNED 0x1
+#define	NVIDIA_P2P_MAPPED 0x2
+
+#define NVIDIA_P2P_MAJOR_VERSION_MASK   0xffff0000
+#define NVIDIA_P2P_MINOR_VERSION_MASK   0x0000ffff
+
+#define NVIDIA_P2P_MAJOR_VERSION(v) \
+	(((v) & NVIDIA_P2P_MAJOR_VERSION_MASK) >> 16)
+
+#define NVIDIA_P2P_MINOR_VERSION(v) \
+	(((v) & NVIDIA_P2P_MINOR_VERSION_MASK))
+
+#define NVIDIA_P2P_MAJOR_VERSION_MATCHES(p, v) \
+	(NVIDIA_P2P_MAJOR_VERSION((p)->version) == NVIDIA_P2P_MAJOR_VERSION(v))
+
+#define NVIDIA_P2P_VERSION_COMPATIBLE(p, v)    \
+	(NVIDIA_P2P_MAJOR_VERSION_MATCHES(p, v) && \
+	(NVIDIA_P2P_MINOR_VERSION((p)->version) >= \
+	(NVIDIA_P2P_MINOR_VERSION(v))))
+
+enum nvidia_p2p_page_size_type {
+	NVIDIA_P2P_PAGE_SIZE_4KB = 0,
+	NVIDIA_P2P_PAGE_SIZE_64KB,
+	NVIDIA_P2P_PAGE_SIZE_128KB,
+	NVIDIA_P2P_PAGE_SIZE_COUNT
+};
+
+typedef struct nvidia_p2p_page_table {
+	u32 version;
+	u32 page_size;
+	u64 size;
+	u32 entries;
+	struct page **pages;
+
+	u64 vaddr;
+	u32 mapped;
+
+	struct mm_struct *mm;
+	struct mmu_notifier mn;
+	struct mutex lock;
+	void (*free_callback)(void *data);
+	void *data;
+} nvidia_p2p_page_table_t;
+
+typedef struct nvidia_p2p_dma_mapping {
+	u32 version;
+	dma_addr_t *hw_address;
+	u32 *hw_len;
+	u32 entries;
+
+	struct sg_table *sgt;
+	struct device *dev;
+	struct nvidia_p2p_page_table *page_table;
+	enum dma_data_direction direction;
+} nvidia_p2p_dma_mapping_t;
+
+#define NVIDIA_P2P_PAGE_TABLE_VERSION   0x00010000
+
+#define NVIDIA_P2P_PAGE_TABLE_VERSION_COMPATIBLE(p) \
+	NVIDIA_P2P_VERSION_COMPATIBLE(p, NVIDIA_P2P_PAGE_TABLE_VERSION)
+
+/*
+ * @brief
+ *   Make the pages underlying a range of GPU virtual memory
+ *   accessible to a third-party device.
+ *
+ * @param[in]     vaddr
+ *   A GPU Virtual Address
+ * @param[in]     size
+ *   The size of the requested mapping.
+ *   Size must be a multiple of Page size.
+ * @param[out]    **page_table
+ *   A pointer to struct nvidia_p2p_page_table
+ * @param[in]     free_callback
+ *   A non-NULL pointer to the function to be invoked when the pages
+ *   underlying the virtual address range are freed
+ *   implicitly. Must be non NULL.
+ * @param[in]     data
+ *   A non-NULL opaque pointer to private data to be passed to the
+ *   callback function.
+ *
+ * @return
+ *    0           upon successful completion.
+ *    Negative number if any error
+ */
+int nvidia_p2p_get_pages(u64 vaddr, u64 size,
+			struct nvidia_p2p_page_table **page_table,
+			void (*free_callback)(void *data), void *data);
+/*
+ * @brief
+ * Release the pages previously made accessible to
+ * a third-party device.
+ *
+ * @param[in]    *page_table
+ *   A pointer to struct nvidia_p2p_page_table
+ *
+ * @return
+ *    0           upon successful completion.
+ *   -ENOMEM      if the driver failed to allocate memory or if
+ *     insufficient resources were available to complete the operation.
+ *    Negative number if any other error
+ */
+int nvidia_p2p_put_pages(struct nvidia_p2p_page_table *page_table);
+
+/*
+ * @brief
+ * Release the pages previously made accessible to
+ * a third-party device. This is called  during the
+ * execution of the free_callback().
+ *
+ * @param[in]    *page_table
+ *   A pointer to struct nvidia_p2p_page_table
+ *
+ * @return
+ *    0           upon successful completion.
+ *   -ENOMEM      if the driver failed to allocate memory or if
+ *     insufficient resources were available to complete the operation.
+ *    Negative number if any other error
+ */
+int nvidia_p2p_free_page_table(struct nvidia_p2p_page_table *page_table);
+
+#define NVIDIA_P2P_DMA_MAPPING_VERSION   0x00010000
+
+#define NVIDIA_P2P_DMA_MAPPING_VERSION_COMPATIBLE(p) \
+	NVIDIA_P2P_VERSION_COMPATIBLE(p, NVIDIA_P2P_DMA_MAPPING_VERSION)
+
+/*
+ * @brief
+ *   Map the pages retrieved using nvidia_p2p_get_pages and
+ *   pass the dma address to a third-party device.
+ *
+ * @param[in]	*dev
+ *   The peer device that needs to DMA to/from the
+ *   mapping.
+ * @param[in]	*page_table
+ *   A pointer to struct nvidia_p2p_page_table
+ * @param[out]	**map
+ *   A pointer to struct nvidia_p2p_dma_mapping.
+ *   The DMA mapping containing the DMA addresses to use.
+ * @param[in]    direction
+ *   DMA direction
+ *
+ * @return
+ *    0           upon successful completion.
+ *    Negative number if any other error
+ */
+int nvidia_p2p_dma_map_pages(struct device *dev,
+		struct nvidia_p2p_page_table *page_table,
+		struct nvidia_p2p_dma_mapping **map,
+		enum dma_data_direction direction);
+/*
+ * @brief
+ *   Unmap the pages previously mapped using nvidia_p2p_dma_map_pages
+ *
+ * @param[in]	*map
+ *   A pointer to struct nvidia_p2p_dma_mapping.
+ *   The DMA mapping containing the DMA addresses to use.
+ *
+ * @return
+ *    0           upon successful completion.
+ *    Negative number if any other error
+ */
+int nvidia_p2p_dma_unmap_pages(struct nvidia_p2p_dma_mapping *map);
+
+/*
+ * @brief
+ *   Unmap the pages previously mapped using nvidia_p2p_dma_map_pages.
+ *  This is called  during the  execution of the free_callback().
+ *
+ * @param[in]	*map
+ *   A pointer to struct nvidia_p2p_dma_mapping.
+ *   The DMA mapping containing the DMA addresses to use.
+ *
+ * @return
+ *    0           upon successful completion.
+ *    Negative number if any other error
+ */
+int nvidia_p2p_free_dma_mapping(struct nvidia_p2p_dma_mapping *dma_mapping);
+
+#endif

--- a/nv_peer_mem
+++ b/nv_peer_mem
@@ -8,7 +8,7 @@
 CONFIG=${CONFIG:-"/etc/infiniband/nv_peer_mem.conf"}
 
 modname=nv_peer_mem
-reqmods="ib_core nvidia"
+reqmods="ib_core nvgpu"
 
 if [ ! -f $CONFIG ]; then
     echo No configuration file found for $modname

--- a/nv_peer_mem.c
+++ b/nv_peer_mem.c
@@ -324,7 +324,9 @@ static int nv_dma_map(struct sg_table *sg_head, void *context,
 	nv_mem_context->sg_allocated = 1;
 	for_each_sg(sg_head->sgl, sg, nv_mem_context->npages, i) {
 		sg_set_page(sg, NULL, nv_mem_context->page_size, 0);
-		sg->dma_address = page_table->pages[i]->physical_address;
+//		sg->dma_address = page_table->pages[i]->physical_address;
+// Xavier fix
+		sg->dma_address = page_to_phys(page_table->pages[i]); //FIXME: this may not be correct
 		sg->dma_length = nv_mem_context->page_size;
 	}
 

--- a/nv_peer_mem.c
+++ b/nv_peer_mem.c
@@ -212,14 +212,19 @@ static int nv_mem_acquire(unsigned long addr, size_t size, void *peer_mem_privat
 	nv_mem_context->page_virt_end   = (addr + size + GPU_PAGE_SIZE - 1) & GPU_PAGE_MASK;
 	nv_mem_context->mapped_size  = nv_mem_context->page_virt_end - nv_mem_context->page_virt_start;
 
-	ret = nvidia_p2p_get_pages(0, 0, nv_mem_context->page_virt_start, nv_mem_context->mapped_size,
+//	ret = nvidia_p2p_get_pages(0, 0, nv_mem_context->page_virt_start, nv_mem_context->mapped_size,
+//			&nv_mem_context->page_table, nv_mem_dummy_callback, nv_mem_context);
+// xavier fix
+	ret = nvidia_p2p_get_pages(nv_mem_context->page_virt_start, nv_mem_context->mapped_size,
 			&nv_mem_context->page_table, nv_mem_dummy_callback, nv_mem_context);
 
 	if (ret < 0)
 		goto err;
 
-	ret = nvidia_p2p_put_pages(0, 0, nv_mem_context->page_virt_start,
-				   nv_mem_context->page_table);
+//	ret = nvidia_p2p_put_pages(0, 0, nv_mem_context->page_virt_start,
+//				   nv_mem_context->page_table);
+// Xavier fix
+	ret = nvidia_p2p_put_pages(nv_mem_context->page_table);
 	if (ret < 0) {
 		/* Not expected, however in case callback was called on that buffer just before
 		    put pages we'll expect to fail gracefully (confirmed by NVIDIA) and return an error.
@@ -266,16 +271,20 @@ static int nv_dma_map(struct sg_table *sg_head, void *context,
 			return -EINVAL;
 		}
 
-		ret = nvidia_p2p_dma_map_pages(pdev, page_table, &dma_mapping);
-		if (ret) {
+//		ret = nvidia_p2p_dma_map_pages(pdev, page_table, &dma_mapping);
+// Xavier Fix
+		ret = nvidia_p2p_dma_map_pages(pdev->dev, page_table, &dma_mapping,DMA_BIDIRECTIONAL); //FIXME which direction TBD
+		if (ret) {,DMA_BIDIRECTIONAL)
 			peer_err("nv_dma_map -- error %d while calling nvidia_p2p_dma_map_pages()\n", ret);
 			return ret;
-		}
+		},DMA_BIDIRECTIONAL)
 
 		if (!NVIDIA_P2P_DMA_MAPPING_VERSION_COMPATIBLE(dma_mapping)) {
 			peer_err("error, incompatible dma mapping version 0x%08x\n",
 				 dma_mapping->version);
-			nvidia_p2p_dma_unmap_pages(pdev, page_table, dma_mapping);
+//			nvidia_p2p_dma_unmap_pages(pdev, page_table, dma_mapping);
+// Xavier fix
+			nvidia_p2p_dma_unmap_pages(dma_mapping);
 			return -EINVAL;
 		}
 
@@ -283,7 +292,9 @@ static int nv_dma_map(struct sg_table *sg_head, void *context,
 
 		ret = sg_alloc_table(sg_head, dma_mapping->entries, GFP_KERNEL);
 		if (ret) {
-			nvidia_p2p_dma_unmap_pages(pdev, page_table, dma_mapping);
+//			nvidia_p2p_dma_unmap_pages(pdev, page_table, dma_mapping);
+// Xavier fix
+			nvidia_p2p_dma_unmap_pages(dma_mapping);
 			return ret;
 		}
 
@@ -342,8 +353,10 @@ static int nv_dma_unmap(struct sg_table *sg_head, void *context,
 	{
 		struct pci_dev *pdev = to_pci_dev(dma_device);
 		if (nv_mem_context->dma_mapping)
-			nvidia_p2p_dma_unmap_pages(pdev, nv_mem_context->page_table,
-						   nv_mem_context->dma_mapping);
+//			nvidia_p2p_dma_unmap_pages(pdev, nv_mem_context->page_table,
+//						   nv_mem_context->dma_mapping);
+// Xavier fix
+		nvidia_p2p_dma_unmap_pages(nv_mem_context->dma_mapping);
 	}
 #endif
 
@@ -361,8 +374,10 @@ static void nv_mem_put_pages(struct sg_table *sg_head, void *context)
 	if (READ_ONCE(nv_mem_context->is_callback))
 		goto out;
 
-	ret = nvidia_p2p_put_pages(0, 0, nv_mem_context->page_virt_start,
-				   nv_mem_context->page_table);
+//	ret = nvidia_p2p_put_pages(0, 0, nv_mem_context->page_virt_start,
+//				   nv_mem_context->page_table);
+// Xavier fix
+	ret = nvidia_p2p_put_pages(nv_mem_context->page_table);
 
 #ifdef _DEBUG_ONLY_
 	/* Here we expect an error in real life cases that should be ignored - not printed.
@@ -413,8 +428,11 @@ static int nv_mem_get_pages(unsigned long addr,
 
 	nv_mem_context->core_context = core_context;
 	nv_mem_context->page_size = GPU_PAGE_SIZE;
-
-	ret = nvidia_p2p_get_pages(0, 0, nv_mem_context->page_virt_start, nv_mem_context->mapped_size,
+//
+//	ret = nvidia_p2p_get_pages(0, 0, nv_mem_context->page_virt_start, nv_mem_context->mapped_size,
+//			&nv_mem_context->page_table, nv_get_p2p_free_callback, nv_mem_context);
+// Xavier fix
+	ret = nvidia_p2p_get_pages(nv_mem_context->page_virt_start, nv_mem_context->mapped_size,
 			&nv_mem_context->page_table, nv_get_p2p_free_callback, nv_mem_context);
 	if (ret < 0) {
 		peer_err("nv_mem_get_pages -- error %d while calling nvidia_p2p_get_pages()\n", ret);

--- a/nv_peer_mem.c
+++ b/nv_peer_mem.c
@@ -96,7 +96,7 @@ MODULE_DESCRIPTION("NVIDIA GPU memory plug-in");
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_VERSION(DRV_VERSION);
 
-#define GPU_PAGE_SHIFT   16
+#define GPU_PAGE_SHIFT   /*16*/ 12
 #define GPU_PAGE_SIZE    ((u64)1 << GPU_PAGE_SHIFT)
 #define GPU_PAGE_OFFSET  (GPU_PAGE_SIZE-1)
 #define GPU_PAGE_MASK    (~GPU_PAGE_OFFSET)
@@ -254,13 +254,13 @@ static int nv_dma_map(struct sg_table *sg_head, void *context,
 	struct nv_mem_context *nv_mem_context =
 		(struct nv_mem_context *) context;
 	struct nvidia_p2p_page_table *page_table = nv_mem_context->page_table;
-
+/*
 	if (page_table->page_size != NVIDIA_P2P_PAGE_SIZE_64KB) {
 		peer_err("nv_dma_map -- assumption of 64KB pages failed size_id=%u\n",
 					nv_mem_context->page_table->page_size);
 		return -EINVAL;
 	}
-
+*/
 #if NV_DMA_MAPPING
 	{
 		struct nvidia_p2p_dma_mapping *dma_mapping;

--- a/nv_peer_mem.c
+++ b/nv_peer_mem.c
@@ -47,7 +47,7 @@
 
 
 #define DRV_NAME	"nv_mem"
-#define DRV_VERSION	"1.0-9"
+#define DRV_VERSION	"1.1-0"
 #define DRV_RELDATE	__DATE__
 
 #define peer_err(FMT, ARGS...) printk(KERN_ERR   DRV_NAME " %s:%d " FMT, __FUNCTION__, __LINE__, ## ARGS)

--- a/nvidia_peer_memory.spec
+++ b/nvidia_peer_memory.spec
@@ -1,12 +1,12 @@
 %define debug_package %{nil}
-%{!?_release: %define _release 9}
+%{!?_release: %define _release 0}
 %{!?KVERSION: %define KVERSION %(uname -r)}
 
 %define MODPROBE %(if ( /sbin/modprobe -c | grep -q '^allow_unsupported_modules  *0'); then echo -n "/sbin/modprobe --allow-unsupported-modules"; else echo -n "/sbin/modprobe"; fi )
 
 Summary: nvidia_peer_memory
 Name: nvidia_peer_memory
-Version: 1.0
+Version: 1.1
 Release: %{_release}
 License: GPL
 Group: System Environment/Libraries


### PR DESCRIPTION
port  using nv_peer_mem on NVIDIA jetson Xavier
based on 1.1.0 version so it supports OFED 4.9-4.0.8.0 LTS and CUDA 10.2
changes would probably work for newer releases as well
code quality isn't that great, paths were changed manually
need to add proper #ifdef`s and change documentation.
it's still a beta , but it works (with a connectx3 pro)
i'd be happy if this was available to the community, for now as a separate branch