### PR TITLE
Add support for persistent vidmem pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,22 +37,22 @@ For example, to build on RPM based OS:
     $ ./build_module.sh
     Building source rpm for nvidia_peer_memory...
     
-    Built: /tmp/nvidia_peer_memory-1.2-0.src.rpm
+    Built: /tmp/nvidia_peer_memory-1.3-0.src.rpm
     
     To install run on RPM based OS:
-    # rpmbuild --rebuild /tmp/nvidia_peer_memory-1.2-0.src.rpm
+    # rpmbuild --rebuild /tmp/nvidia_peer_memory-1.3-0.src.rpm
     # rpm -ivh <path to generated binary rpm file>
 
 To build on DEB based OS:
 
     Building debian tarball for nvidia-peer-memory...
     
-    Built: /tmp/nvidia-peer-memory_1.2.orig.tar.gz
+    Built: /tmp/nvidia-peer-memory_1.3.orig.tar.gz
 
     To install on DEB based OS:
     # cd /tmp
-    # tar xzf /tmp/nvidia-peer-memory_1.2.orig.tar.gz
-    # cd nvidia-peer-memory-1.2
+    # tar xzf /tmp/nvidia-peer-memory_1.3.orig.tar.gz
+    # cd nvidia-peer-memory-1.3
     # dpkg-buildpackage -us -uc
     # dpkg -i <path to generated deb files>            
 
@@ -66,8 +66,8 @@ To install on Ubuntu run:
     dpkg-buildpackage -us -uc
     dpkg -i <path to generated deb files.>
 
-    (e.g. dpkg -i nvidia-peer-memory_1.2-0_all.deb
-          dpkg -i nvidia-peer-memory-dkms_1.2-0_all.deb)
+    (e.g. dpkg -i nvidia-peer-memory_1.3-0_all.deb
+          dpkg -i nvidia-peer-memory-dkms_1.3-0_all.deb)
 
 After successful installation:
 1)	nv_peer_mem.ko is installed

--- a/debian/patches/dkms_name.patch
+++ b/debian/patches/dkms_name.patch
@@ -10,6 +10,6 @@ index 7315b92..0b966e1 100644
  # DKMS module name and version
 -PACKAGE_NAME="nv_peer_mem"
 +PACKAGE_NAME="nvidia-peer-memory"
- PACKAGE_VERSION="1.2"
+ PACKAGE_VERSION="1.3"
  
  kernelver=${kernelver:-$(uname -r)}

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,7 @@
 
 # DKMS module name and version
 PACKAGE_NAME="nv_peer_mem"
-PACKAGE_VERSION="1.2"
+PACKAGE_VERSION="1.3"
 
 kernelver=${kernelver:-$(uname -r)}
 kernel_source_dir=${kernel_source_dir:-/lib/modules/$kernelver/build}

--- a/nv_peer_mem.c
+++ b/nv_peer_mem.c
@@ -46,7 +46,7 @@
 #include <rdma/peer_mem.h>
 
 #define DRV_NAME	"nv_mem"
-#define DRV_VERSION	"1.2-0"
+#define DRV_VERSION	"1.3-0"
 #define DRV_RELDATE	__DATE__
 
 MODULE_AUTHOR("Yishai Hadas");

--- a/nvidia_peer_memory.spec
+++ b/nvidia_peer_memory.spec
@@ -6,7 +6,7 @@
 
 Summary: nvidia_peer_memory
 Name: nvidia_peer_memory
-Version: 1.2
+Version: 1.3
 Release: %{_release}
 License: GPL
 Group: System Environment/Libraries


### PR DESCRIPTION
This PR:
- introduces the NC client.
- introduces `nv_support_persistent_pages` for checking whether nvidia.ko supports persistent pages.
- implements `nv_mem_get_pages_nc` for the NC client to enable the persistent pages feature.
- increases the version number to 1.3.

Note:
- The NC client does not use `struct peer_memory_client_ex` because the invalidation path is not used.